### PR TITLE
add alias exit to quit command

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -41,6 +41,11 @@ void exit_yafc(void)
 	exit(0);
 }
 
+void cmd_exit(int argc, char **argv)
+{
+        cmd_quit(argc,argv);
+}
+
 void cmd_quit(int argc, char **argv)
 {
 	if(argv != 0) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -58,6 +58,7 @@ cmd_t cmds[] = {
 	CMD(put, 0,0,0, cpLocalFile),
 	CMD(pwd, 0,0,1, cpNone),
 	CMD(quit, 0,0,1, cpNone),
+	CMD(exit, 0,0,1, cpNone),
 	CMD(quote, 0,0,1, cpNone),
 	CMD(mv, 0,0,1, cpRemoteFile),
 	CMD(reopen, 1,1,1, cpNone),

--- a/src/commands.h
+++ b/src/commands.h
@@ -77,6 +77,7 @@ extern cpl_t force_completion_type;
 DEFCMD(cachelist);
 DEFCMD(status);
 DEFCMD(quit);
+DEFCMD(exit);
 DEFCMD(filetime);
 DEFCMD(source);
 DEFCMD(system);


### PR DESCRIPTION
this commit adds alias exit to quit command, some people (like me), who type fast and do have a reflex of typing exit when they want to quit yafc console hit "No such command 'exit', try 'help', So this commit adds alias exit to quit command.
