### PR TITLE
Implied -a for ls command when a dot-file is specified

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -11,7 +11,6 @@ known BUGS
 * using a slash ('/') in a bookmarks alias name will lead yafc into thinking
    there is a directory to change into
 * issuing a "ls /usr /var" gives a listing of both directories mixed together
-* issuing a "ls .profile" doesn't list .profile if -a option isn't given
 
 --
 Please report bugs to https://github.com/sebastinas/yafc/issues

--- a/src/list.c
+++ b/src/list.c
@@ -401,6 +401,15 @@ static void lsfiles(list *gl, unsigned opt)
 		ls_recursive(gl, opt, doclr);
 }
 
+static bool contains_dotfiles(int optind, int argc, char **argv)
+{
+	while(optind < argc) {
+		char *e = argv[optind++];
+		if (e[0] == '.') return true;
+	}
+	return false;
+}
+
 /* cached ls */
 void cmd_ls(int argc, char **argv)
 {
@@ -520,6 +529,10 @@ void cmd_ls(int argc, char **argv)
 	need_connected();
 	need_loggedin();
 
+	if(contains_dotfiles(optind, argc, argv)) {
+		opt |= LS_ALL;
+	}
+	
 	gl = rglob_create();
 	dontlist_opt = opt;
 	if(optind >= argc) {


### PR DESCRIPTION
It looks over all of the specified glob-patterns first
and if any of them begin with a ".", it implies the -a
flag.

This allows for:
  ls .htaccess
  ls .ht*
to behave as expected.
