### PR TITLE
General bugfixes found during mingw32 port

### DIFF
--- a/src/ftp/ftp.c
+++ b/src/ftp/ftp.c
@@ -1335,7 +1335,7 @@ rdirectory *ftp_read_directory(const char *path)
     is_curdir = (strcmp(dir, ftp->curdir) == 0);
 
     if((fp = tmpfile()) == NULL) {	/* can't create a tmpfile */
-	    ftp_err("%s\n", strerror(errno));
+	    ftp_err("Unable to create temp file: %s\n", strerror(errno));
             free(dir);
             return 0;
     }


### PR DESCRIPTION
These are issues which aren't windows specific - mainly error caching code. The mingw32 code throws a lot of errors at the moment, and so I have been adding improved error handling, and I always do it as a separate commit, so we can merge them upstream separate from the mingw32 stuff.
