### PR TITLE
Use the proper name for the macro defined if we have strlcpy.

### DIFF
--- a/src/syshdr.h
+++ b/src/syshdr.h
@@ -179,7 +179,7 @@ extern int read_history ();
 #ifdef HAVE_KERBEROS
 # define SECFTP
 # include "security.h"  /* our own, in lib/ */
-# ifndef HAVE_STRLCPY
+# ifndef HAVE_DECL_STRLCPY
 size_t strlcpy (char *dst, const char *src, size_t dst_sz);
 # endif
 #endif


### PR DESCRIPTION
Fixes sebastinas/yafc#35
