### PR TITLE
Change readline version check to <6.2

### DIFF
--- a/src/syshdr.h
+++ b/src/syshdr.h
@@ -161,7 +161,7 @@ extern int read_history ();
 #define HAVE_LIBREADLINE
 #endif
 
-#if defined(HAVE_LIBEDIT) || (defined(HAVE_LIBREADLINE) && RL_READLINE_VERSION < 0x0603)
+#if defined(HAVE_LIBEDIT) || (defined(HAVE_LIBREADLINE) && RL_READLINE_VERSION < 0x0602)
 typedef CPPFunction rl_completion_func_t;
 #endif
 


### PR DESCRIPTION
Required for compilation on Fedora against readline version 6.2
