### PR TITLE
Fix double free bug

### DIFF
--- a/src/libmhe/args.c
+++ b/src/libmhe/args.c
@@ -133,8 +133,13 @@ static args_t *split_args(const char *str)
 	while(c && (e = strqsep(&c, ' ')) != 0)
 		args->argv[args->argc++] = xstrdup(e);
 
+	if(args->argc == 0) {
+		args_clear(args);
+		goto clean;
+	}
 	args->argv = xrealloc(args->argv, args->argc * sizeof(char *));
 
+clean:
 	free(orgc);
 	return args;
 }

--- a/src/libmhe/xmalloc.c
+++ b/src/libmhe/xmalloc.c
@@ -32,7 +32,8 @@ void* xrealloc(void* ptr, size_t size)
     return xmalloc(size);
 
   void* new_ptr = realloc(ptr, size);
-  if (!new_ptr) {
+  // If size is zero, realloc() is equivalent to free().
+  if (!new_ptr && size != 0) {
     fprintf(stderr, "\nxrealloc(%p, %zu): %s\n", ptr, size, strerror(errno));
     free(ptr);
     exit(errno);


### PR DESCRIPTION
Fix parsing of a command string "; ;", which causes a double free.

Closes #60.