### PR TITLE
Fix switch when disconnected

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -162,6 +162,8 @@ char* get_mode_string(mode_t m)
 
 static int switch_search(const Ftp *f, const char *name)
 {
+	if(!f->url)
+		return 1;
 	if(f->url->alias) {
 		if(strcmp(f->url->alias, name) == 0)
 			return 0;


### PR DESCRIPTION
Using the command "switch name", segfaults when there are no open
connections. Make sure Ftp struct's url field is not NULL, before
checking whether the name matches a connection.

```
yafc> switch a

Program received signal SIGSEGV, Segmentation fault.
0x000000000041988d in switch_search (f=0x6439c0, name=0x664690 "a") at src/utils.c:165
165             if(f->url->alias) {
(gdb) bt
#0  0x000000000041988d in switch_search (f=0x6439c0, name=0x664690 "a") at src/utils.c:165
#1  0x000000000041a111 in list_search (lp=<optimized out>, cmpfunc=cmpfunc@entry=0x419880 <switch_search>, 
    arg=arg@entry=0x664690) at src/libmhe/linklist.c:56
#2  0x0000000000419e02 in ftplist_search (str=0x664690 "a") at src/utils.c:187
#3  0x0000000000409df2 in cmd_switch (argc=2, argv=0x663570) at src/commands.c:862
#4  0x000000000040708e in exe_cmd (args=0x663550, c=0x63eb58 <cmds+984>) at src/cmd.c:197
#5  exe_cmdline (str=0x663388 "", str@entry=0x663380 "switch a", 
    aliases_are_expanded=aliases_are_expanded@entry=true) at src/cmd.c:269
#6  0x000000000040718c in exe_cmdline (str=0x663428 "", str@entry=0x663420 "switch a", 
    aliases_are_expanded=aliases_are_expanded@entry=false) at src/cmd.c:315
#7  0x000000000040746b in command_loop () at src/cmd.c:134
#8  0x0000000000405a95 in main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>) at src/main.c:458
```